### PR TITLE
feat: external upgrade socket connections

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -405,7 +405,8 @@ export default class Server {
         app.use(proxyMiddleware);
         proxies.push({
           proxyMiddleware,
-          ws: options.ws
+          context,
+          options
         });
       }
     }
@@ -456,7 +457,10 @@ export default class Server {
       });
       
       server.on('upgrade', (req, socket, head) => {
-        proxies.filter(({ws}) => ws).forEach(({proxyMiddleware}) => proxyMiddleware.upgrade(req, socket, head)); 
+        // Only upgrade websocket proxies and matching contexts
+        proxies
+          .filter(({context, options}) => options.ws == true && req.headers.upgrade.toLowerCase() === 'websocket' && req.url === context)
+          .forEach(({proxyMiddleware}) => proxyMiddleware.upgrade(req, socket, head)); 
       });
     });
   }

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -365,6 +365,8 @@ export default class Server {
   async applyProxyTable(app: any): Promise<Server> {
     // avoid skipping project root
     const fileInRoot: string = path.join(this.options.projectRoot, '_');
+    const proxies = [];
+  
 
     const pkg = await loadConfig(
       this.options.inputFS,
@@ -374,7 +376,7 @@ export default class Server {
     );
 
     if (!pkg || !pkg.config || !pkg.files) {
-      return this;
+      return proxies;
     }
 
     const cfg = pkg.config;
@@ -386,7 +388,7 @@ export default class Server {
           message:
             "Proxy configuration file '.proxyrc.js' should export a function. Skipping...",
         });
-        return this;
+        return proxies;
       }
       cfg(app);
     } else if (filename === '.proxyrc' || filename === '.proxyrc.json') {
@@ -399,11 +401,16 @@ export default class Server {
       }
       for (const [context, options] of Object.entries(cfg)) {
         // each key is interpreted as context, and value as middleware options
-        app.use(createProxyMiddleware(context, options));
+        const proxyMiddleware = createProxyMiddleware(context, options);
+        app.use(proxyMiddleware);
+        proxies.push({
+          proxyMiddleware,
+          ws: options.ws
+        });
       }
     }
 
-    return this;
+    return proxies;
   }
 
   async start(): Promise<HTTPServer> {
@@ -419,7 +426,7 @@ export default class Server {
     };
 
     const app = connect();
-    await this.applyProxyTable(app);
+    const proxies = await this.applyProxyTable(app);
     app.use(finalHandler);
 
     let {server, stop} = await createHTTPServer({
@@ -433,6 +440,7 @@ export default class Server {
     this.stopServer = stop;
 
     server.listen(this.options.port, this.options.host);
+
     return new Promise((resolve, reject) => {
       server.once('error', err => {
         this.options.logger.error(
@@ -445,6 +453,10 @@ export default class Server {
 
       server.once('listening', () => {
         resolve(server);
+      });
+      
+      server.on('upgrade', (req, socket, head) => {
+        proxies.filter(({ws}) => ws).forEach(({proxyMiddleware}) => proxyMiddleware.upgrade(req, socket, head)); 
       });
     });
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

To get sockets really working, e.g. with apollo server, we need to subscribe externally to socket upgrades.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

If using a .proxyrc and proxy graphql connections with sockets the internal upgrade is failing.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Hard to tell :S. Create a ws proxy and check if it working. 

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
